### PR TITLE
AIP-653: Sym-link python SDK components to avoid poetry lacking subdirectory install capabilities

### DIFF
--- a/kfp
+++ b/kfp
@@ -1,0 +1,1 @@
+sdk/python/kfp

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,1 @@
+sdk/python/setup.py


### PR DESCRIPTION
We want to be able to install the ZG fork of `kfp` with `poetry`.

Unfortunately `poetry` has a limitation where it cannot install `subdirectory` packages for `git` paths, see https://github.com/python-poetry/poetry/issues/755. So to get around this issue we symlink the appropriate Python SDK files to the root directory instead 😅 

---

As an interesting aside another approach considered for this was to publish a package to Github Packages and have the `aip-kfp-sdk` library rely on it but as per https://github.com/github/roadmap/issues/94 python packages are not support 😒  For the future open-source workstream it is likely we'll want to publish packages to the global PyPI.