### PR TITLE
AIP-3158: Add in ability to override the template handler for a BaseOp.

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -638,7 +638,8 @@ class Compiler(object):
       templates.append(template)
 
     for op in pipeline.ops.values():
-      templates.extend(op_to_templates_handler(op))
+      op_to_template_handler = op.template_handler or op_to_templates_handler
+      templates.extend(op_to_template_handler(op))
 
     return templates
 

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -727,6 +727,7 @@ class BaseOp(object):
             warnings.warn('is_exit_handler=True is no longer needed.', DeprecationWarning)
 
         self.is_exit_handler = is_exit_handler
+        self.template_handler = None
 
         # human_name must exist to construct operator's name
         self.human_name = name
@@ -924,6 +925,16 @@ class BaseOp(object):
 
     def set_display_name(self, name: str):
         self.display_name = name
+        return self
+
+    def set_template_handler(self, template_handler: Callable[['BaseOp'], Dict]):
+        """Set the template handler for converting Op into Argo template.
+
+        Args:
+          template_handler: A callable for converting the BaseOp into an Argo template during
+            pipeline compilation.
+        """
+        self.template_handler = template_handler
         return self
 
     def __repr__(self):

--- a/sdk/python/kfp/dsl/_container_op.py
+++ b/sdk/python/kfp/dsl/_container_op.py
@@ -927,11 +927,11 @@ class BaseOp(object):
         self.display_name = name
         return self
 
-    def set_template_handler(self, template_handler: Callable[['BaseOp'], Dict]):
+    def set_template_handler(self, template_handler: Callable[['BaseOp'], List[Dict]]):
         """Set the template handler for converting Op into Argo template.
 
         Args:
-          template_handler: A callable for converting the BaseOp into an Argo template during
+          template_handler: A callable for converting the BaseOp into Argo templates during
             pipeline compilation.
         """
         self.template_handler = template_handler


### PR DESCRIPTION
Add in ability to override the default template converting function, by default this is `_op_to_template`, see [here](https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/compiler/_op_to_template.py#L176). This converts a `kfp.dsl.ContainerOp` to an Argo `Workflow.spec.template` dictionary.

I expect we can use this in the Metaflow on KFP codebase to support:
1. `podSecurityContext` - Needed by Spark workstream to read AWS IAM credential token file mounted within container by only accessible via the `root` user.
2. `podSpecPatch` - Not really needed yet (except maybe to set Spark driver pod resources dynamically if running in `client` mode), but unlocks dynamic setting of CPU, Memory and GPU resources within an Argo Workflow at runtime (currently we're limited to just compile time!).
    * This would unlock RentZest to dynamically allocate step pod sizes based on county data partition sizes.

You'd use this by doing:

```python
from typing import Dict
from kfp.compiler._op_to_template import _op_to_template
from kfp.dsl._container_op import BaseOp

def my_template_handler(op: BaseOp) -> Dict:
    template = _op_to_template(op)
    # See https://argoproj.github.io/argo/fields/#podsecuritycontext
    # fsGroup will set the ownership of any mounted files to the group ID supplied, 65534 is the
    # default gid for default "nogroup" which all users in a linux system get added to.
    template['securityContext'] = {"fsGroup": 65534}
    return template
```

Then within the KFP plugin within Metaflow we'd define that and use it:

```python
...
# See https://github.com/zillow/metaflow/blob/feature/kfp/metaflow/plugins/kfp/kfp.py#L331
step_to_kfp_component_map[step_name] = build_kfp_component(node, task_id)
step_to_kfp_component_map[step_name].set_template_handler(my_template_handler)
...
```

What will happen now when the flow is compiled to Argo Workflow YAML the `spec.templates[...].securityContext` field will be set with permissions needed to read the AWS IAM token file!

To do:
- [x] Add in API for amending Argo workflow templates.
- [x] Push PR up to `kfp` Open Source, see https://github.com/kubeflow/pipelines/pull/4955
- [ ] Discuss how best to introduce integration for this in Metaflow, need to speak with @talebzeghmi on this.

PS. I'm discussing with Xiaowei about setting up a dedicated `zservice` group so we don't rely on the default `nogroup` :) 