### PR TITLE
feat(sdk): AIP-4946: Update KFP CLI to support recurring runs, archiving experiments and deleting pipeline versions.

### DIFF
--- a/sdk/python/kfp/_client.py
+++ b/sdk/python/kfp/_client.py
@@ -338,7 +338,7 @@ class Client(object):
     config.refresh_api_key_hook(config)
     return config
 
-  def set_user_namespace(self, namespace):
+  def set_user_namespace(self, namespace: str):
     """Set user namespace into local context setting file.
 
     This function should only be used when Kubeflow Pipelines is in the multi-user mode.
@@ -352,7 +352,7 @@ class Client(object):
     with open(Client.LOCAL_KFP_CONTEXT, 'w') as f:
       json.dump(self._context_setting, f)
 
-  def get_kfp_healthz(self):
+  def get_kfp_healthz(self) -> kfp_server_api.ApiGetHealthzResponse:
     """Gets healthz info of KFP deployment.
 
     Returns:
@@ -375,7 +375,7 @@ class Client(object):
         logging.exception('Failed to get healthz info attempt {} of 5.'.format(count))
         time.sleep(5)
 
-  def get_user_namespace(self):
+  def get_user_namespace(self) -> str:
     """Get user namespace in context config.
 
     Returns:
@@ -383,7 +383,7 @@ class Client(object):
     """
     return self._context_setting['namespace']
 
-  def create_experiment(self, name, description=None, namespace=None):
+  def create_experiment(self, name, description=None, namespace=None) -> kfp_server_api.ApiExperiment:
     """Create a new experiment.
 
     Args:
@@ -410,11 +410,11 @@ class Client(object):
 
       resource_references = []
       if namespace:
-        key = kfp_server_api.models.ApiResourceKey(id=namespace, type=kfp_server_api.models.ApiResourceType.NAMESPACE)
-        reference = kfp_server_api.models.ApiResourceReference(key=key, relationship=kfp_server_api.models.ApiRelationship.OWNER)
+        key = kfp_server_api.ApiResourceKey(id=namespace, type=kfp_server_api.ApiResourceType.NAMESPACE)
+        reference = kfp_server_api.ApiResourceReference(key=key, relationship=kfp_server_api.ApiRelationship.OWNER)
         resource_references.append(reference)
 
-      experiment = kfp_server_api.models.ApiExperiment(
+      experiment = kfp_server_api.ApiExperiment(
         name=name,
         description=description,
         resource_references=resource_references)
@@ -428,7 +428,7 @@ class Client(object):
       IPython.display.display(IPython.display.HTML(html))
     return experiment
 
-  def get_pipeline_id(self, name):
+  def get_pipeline_id(self, name) -> Optional[str]:
     """Find the id of a pipeline by name.
 
     Args:
@@ -455,7 +455,7 @@ class Client(object):
       raise ValueError("Multiple pipelines with the name: {} found, the name needs to be unique".format(name))
     return None
 
-  def list_experiments(self, page_token='', page_size=10, sort_by='', namespace=None):
+  def list_experiments(self, page_token='', page_size=10, sort_by='', namespace=None) -> kfp_server_api.ApiListExperimentsResponse:
     """List experiments.
 
     Args:
@@ -474,11 +474,11 @@ class Client(object):
       page_token=page_token,
       page_size=page_size,
       sort_by=sort_by,
-      resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.NAMESPACE,
+      resource_reference_key_type=kfp_server_api.api_resource_type.ApiResourceType.NAMESPACE,
       resource_reference_key_id=namespace)
     return response
 
-  def get_experiment(self, experiment_id=None, experiment_name=None, namespace=None):
+  def get_experiment(self, experiment_id=None, experiment_name=None, namespace=None) -> kfp_server_api.ApiExperiment:
     """Get details of an experiment
 
     Either experiment_id or experiment_name is required
@@ -493,8 +493,8 @@ class Client(object):
     Returns:
       A response object including details of a experiment.
 
-    Throws:
-      Exception if experiment is not found or None of the arguments is provided
+    Raises:
+      kfp_server_api.ApiException: If experiment is not found or None of the arguments is provided
     """
     namespace = namespace or self.get_user_namespace()
     if experiment_id is None and experiment_name is None:
@@ -513,7 +513,7 @@ class Client(object):
     if namespace:
       result = self._experiment_api.list_experiment(
         filter=experiment_filter,
-        resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.NAMESPACE, 
+        resource_reference_key_type=kfp_server_api.api_resource_type.ApiResourceType.NAMESPACE, 
         resource_reference_key_id=namespace)
     else:
       result = self._experiment_api.list_experiment(filter=experiment_filter)
@@ -522,6 +522,20 @@ class Client(object):
     if len(result.experiments) > 1:
       raise ValueError('Multiple experiments is found with name {}.'.format(experiment_name))
     return result.experiments[0]
+
+  def archive_experiment(self, experiment_id: str):
+    """Archive experiment.
+
+    Args:
+      experiment_id: id of the experiment.
+
+    Returns:
+      Object. If the method is called asynchronously, returns the request thread.
+
+    Raises:
+      kfp_server_api.ApiException: If experiment is not found.
+    """
+    return self._experiment_api.archive_experiment(experiment_id)
 
   def delete_experiment(self, experiment_id):
     """Delete experiment.
@@ -532,8 +546,8 @@ class Client(object):
     Returns:
       Object. If the method is called asynchronously, returns the request thread.
 
-    Throws:
-      Exception if experiment is not found.
+    Raises:
+      kfp_server_api.ApiException: If experiment is not found.
     """
     return self._experiment_api.delete_experiment(id=experiment_id)
 
@@ -575,7 +589,7 @@ class Client(object):
          and 'pipelines.kubeflow.org/enable_caching' in template['metadata']['labels']:
         template['metadata']['labels']['pipelines.kubeflow.org/enable_caching'] = str(enable_caching).lower()
 
-  def list_pipelines(self, page_token='', page_size=10, sort_by=''):
+  def list_pipelines(self, page_token='', page_size=10, sort_by='') -> kfp_server_api.ApiListPipelinesResponse:
     """List pipelines.
 
     Args:
@@ -588,7 +602,7 @@ class Client(object):
     """
     return self._pipelines_api.list_pipelines(page_token=page_token, page_size=page_size, sort_by=sort_by)
 
-  def list_pipeline_versions(self, pipeline_id: str, page_token='', page_size=10, sort_by=''):
+  def list_pipeline_versions(self, pipeline_id: str, page_token='', page_size=10, sort_by='') -> kfp_server_api.ApiListPipelineVersionsResponse:
     """List all versions of a given pipeline.
 
     Args:
@@ -619,7 +633,7 @@ class Client(object):
       version_id: Optional[str] = None,
       pipeline_root: Optional[str] = None,
       enable_caching: Optional[str] = None,
-  ):
+  ) -> kfp_server_api.ApiRun:
     """Run a specified pipeline.
 
     Args:
@@ -660,7 +674,7 @@ class Client(object):
       version_id=version_id,
       enable_caching=enable_caching,
     )
-    run_body = kfp_server_api.models.ApiRun(
+    run_body = kfp_server_api.ApiRun(
         pipeline_spec=job_config.spec, resource_references=job_config.resource_references, name=job_name)
 
     response = self._run_api.create_run(body=run_body)
@@ -674,8 +688,9 @@ class Client(object):
 
   def create_recurring_run(
       self,
-      experiment_id: str,
       job_name: str,
+      experiment_id: Optional[str] = None,
+      experiment_name: Optional[str] = None,
       description: Optional[str] = None,
       start_time: Optional[str] = None,
       end_time: Optional[str] = None,
@@ -689,11 +704,12 @@ class Client(object):
       version_id: Optional[str] = None,
       enabled: bool = True,
       enable_caching: Optional[bool] = None,
-  ):
+  ) -> kfp_server_api.ApiJob:
     """Create a recurring run.
 
     Args:
       experiment_id: The string id of an experiment.
+      experiment_name: The string name of an experiment.
       job_name: Name of the job.
       description: An optional job description.
       start_time: The RFC3339 time string of the time when to start the job.
@@ -723,10 +739,19 @@ class Client(object):
         individual tasks.
         If set, the setting applies to all tasks in the pipeline -- overrides
         the compile time settings.
-
+    
     Returns:
       A Job object. Most important field is id.
+
+    Raises:
+      ValueError: If required parameters are not supplied.
     """
+    if experiment_id is None and experiment_name is None:
+      raise ValueError('Either job_id or experiment_name is required')
+    if not experiment_id:
+      experiment = self.create_experiment(experiment_name)
+      experiment_id = experiment.id
+
     job_config = self._create_job_config(
       experiment_id=experiment_id,
       params=params,
@@ -739,17 +764,17 @@ class Client(object):
     if all([interval_second, cron_expression]) or not any([interval_second, cron_expression]):
       raise ValueError('Either interval_second or cron_expression is required')
     if interval_second is not None:
-      trigger = kfp_server_api.models.ApiTrigger(
-        periodic_schedule=kfp_server_api.models.ApiPeriodicSchedule(
+      trigger = kfp_server_api.ApiTrigger(
+        periodic_schedule=kfp_server_api.ApiPeriodicSchedule(
           start_time=start_time, end_time=end_time, interval_second=interval_second)
       )
     if cron_expression is not None:
-      trigger = kfp_server_api.models.ApiTrigger(
-        cron_schedule=kfp_server_api.models.ApiCronSchedule(
+      trigger = kfp_server_api.ApiTrigger(
+        cron_schedule=kfp_server_api.ApiCronSchedule(
         start_time=start_time, end_time=end_time, cron=cron_expression)
       )
 
-    job_body = kfp_server_api.models.ApiJob(
+    job_body = kfp_server_api.ApiJob(
         enabled=enabled,
         pipeline_spec=job_config.spec,
         resource_references=job_config.resource_references,
@@ -810,20 +835,20 @@ class Client(object):
         name=sanitize_k8s_name(name=k, allow_capital_underscore=True),
         value=str(v) if type(v) not in (list, dict) else json.dumps(v)) for k,v in params.items()]
     resource_references = []
-    key = kfp_server_api.models.ApiResourceKey(id=experiment_id,
-                                        type=kfp_server_api.models.ApiResourceType.EXPERIMENT)
-    reference = kfp_server_api.models.ApiResourceReference(key=key,
-                                                           relationship=kfp_server_api.models.ApiRelationship.OWNER)
+    key = kfp_server_api.ApiResourceKey(id=experiment_id,
+                                        type=kfp_server_api.ApiResourceType.EXPERIMENT)
+    reference = kfp_server_api.ApiResourceReference(key=key,
+                                                           relationship=kfp_server_api.ApiRelationship.OWNER)
     resource_references.append(reference)
 
     if version_id:
-      key = kfp_server_api.models.ApiResourceKey(id=version_id,
-                                                 type=kfp_server_api.models.ApiResourceType.PIPELINE_VERSION)
-      reference = kfp_server_api.models.ApiResourceReference(key=key,
-                                                             relationship=kfp_server_api.models.ApiRelationship.CREATOR)
+      key = kfp_server_api.ApiResourceKey(id=version_id,
+                                                 type=kfp_server_api.ApiResourceType.PIPELINE_VERSION)
+      reference = kfp_server_api.ApiResourceReference(key=key,
+                                                             relationship=kfp_server_api.ApiRelationship.CREATOR)
       resource_references.append(reference)
 
-    spec = kfp_server_api.models.ApiPipelineSpec(
+    spec = kfp_server_api.ApiPipelineSpec(
         pipeline_id=pipeline_id,
         workflow_manifest=pipeline_json_string,
         parameters=api_params)
@@ -968,7 +993,7 @@ class Client(object):
     )
     return RunPipelineResult(self, run_info)
 
-  def list_runs(self, page_token='', page_size=10, sort_by='', experiment_id=None, namespace=None):
+  def list_runs(self, page_token='', page_size=10, sort_by='', experiment_id=None, namespace=None) -> kfp_server_api.ApiListRunsResponse:
     """List runs, optionally can be filtered by experiment or namespace.
 
     Args:
@@ -985,14 +1010,14 @@ class Client(object):
     """
     namespace = namespace or self.get_user_namespace()
     if experiment_id is not None:
-      response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.EXPERIMENT, resource_reference_key_id=experiment_id)
+      response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.api_resource_type.ApiResourceType.EXPERIMENT, resource_reference_key_id=experiment_id)
     elif namespace:
-      response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.NAMESPACE, resource_reference_key_id=namespace)
+      response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.api_resource_type.ApiResourceType.NAMESPACE, resource_reference_key_id=namespace)
     else:
       response = self._run_api.list_runs(page_token=page_token, page_size=page_size, sort_by=sort_by)
     return response
 
-  def list_recurring_runs(self, page_token='', page_size=10, sort_by='', experiment_id=None):
+  def list_recurring_runs(self, page_token='', page_size=10, sort_by='', experiment_id=None) -> kfp_server_api.ApiListJobsResponse:
     """List recurring runs.
 
     Args:
@@ -1005,27 +1030,65 @@ class Client(object):
       A response object including a list of recurring_runs and next page token.
     """
     if experiment_id is not None:
-      response = self._job_api.list_jobs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.EXPERIMENT, resource_reference_key_id=experiment_id)
+      response = self._job_api.list_jobs(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_reference_key_type=kfp_server_api.api_resource_type.ApiResourceType.EXPERIMENT, resource_reference_key_id=experiment_id)
     else:
       response = self._job_api.list_jobs(page_token=page_token, page_size=page_size, sort_by=sort_by)
     return response
 
-  def get_recurring_run(self, job_id):
+  def get_recurring_run(self, job_id: str = None, job_name: str = None, namespace: str = None) -> kfp_server_api.ApiJob:
     """Get recurring_run details.
 
     Args:
       job_id: id of the recurring_run.
+      job_name: name of the recurring_run.
 
     Returns:
       A response object including details of a recurring_run.
 
-    Throws:
-      Exception if recurring_run is not found.
+    Raises:
+      ValueError: If required fields are not supplied.
+      kfp_server_api.ApiException: If recurring_run is not found.
     """
-    return self._job_api.get_job(id=job_id)
+    namespace = namespace or self.get_user_namespace()
+    if job_id is None and job_name is None:
+      raise ValueError('Either job_id or job_name is required')
+    if job_id is not None:
+      return self._job_api.get_job(id=job_id)
 
+    recurring_run_filter = json.dumps({ 
+        "predicates": [ 
+          { 
+            "op":  _FILTER_OPERATIONS["EQUALS"], 
+            "key": "name", 
+            "stringValue": job_name, 
+          }
+        ] 
+      })
+    if namespace:
+      result = self._job_api.list_jobs(
+        filter=recurring_run_filter,
+        resource_reference_key_type=kfp_server_api.api_resource_type.ApiResourceType.NAMESPACE, 
+        resource_reference_key_id=namespace)
+    else:
+      result = self._job_api.list_jobs(filter=recurring_run_filter)
+    if not result.jobs:
+      raise ValueError(f'No recurring runs found with name {job_name}.')
+    if len(result.jobs) > 1:
+      raise ValueError(f'Multiple recurring runs found with name {job_name}.')
+    return result.jobs[0]
 
-  def get_run(self, run_id):
+  def delete_recurring_run(self, job_id: str):
+    """Delete a recurring_run.
+
+    Args:
+      job_id: id of the recurring_run.
+
+    Raises:
+      kfp_server_api.ApiException: If recurring_run is not found.
+    """
+    self._job_api.delete_job(job_id)
+
+  def get_run(self, run_id) -> kfp_server_api.ApiRun:
     """Get run details.
 
     Args:
@@ -1034,8 +1097,8 @@ class Client(object):
     Returns:
       A response object including details of a run.
 
-    Throws:
-      Exception if run is not found.
+    Raises:
+       kfp_server_api.ApiException: If run is not found.
     """
     return self._run_api.get_run(run_id=run_id)
 
@@ -1093,7 +1156,7 @@ class Client(object):
     pipeline_package_path: str = None,
     pipeline_name: str = None,
     description: str = None,
-  ):
+  ) -> kfp_server_api.ApiPipeline:
     """Uploads the pipeline to the Kubeflow Pipelines cluster.
 
     Args:
@@ -1119,7 +1182,7 @@ class Client(object):
     pipeline_id: Optional[str] = None,
     pipeline_name: Optional[str] = None,
     description: Optional[str] = None,
-  ):
+  ) -> kfp_server_api.ApiPipelineVersion:
     """Uploads a new version of the pipeline to the Kubeflow Pipelines cluster.
     Args:
       pipeline_package_path: Local path to the pipeline package.
@@ -1127,9 +1190,11 @@ class Client(object):
       pipeline_id: Optional. Id of the pipeline.
       pipeline_name: Optional. Name of the pipeline.
       description: Optional. Description of the pipeline version to be shown in the UI.
+
     Returns:
       Server response object containing pipleine id and other information.
-    Throws:
+
+    Raises:
       ValueError when none or both of pipeline_id or pipeline_name are specified
       Exception if pipeline id is not found.
     """
@@ -1153,19 +1218,41 @@ class Client(object):
       IPython.display.display(IPython.display.HTML(html))
     return response
 
-  def get_pipeline(self, pipeline_id):
+  def get_pipeline(self, pipeline_id: str = None, pipeline_name: str = None) -> kfp_server_api.ApiPipeline:
     """Get pipeline details.
 
     Args:
       pipeline_id: id of the pipeline.
+      pipeline_id: name of the pipeline.
 
     Returns:
       A response object including details of a pipeline.
 
-    Throws:
-      Exception if pipeline is not found.
+    Raises:
+      ValueError: If required fields are not supplied.
+      kfp_server_api.ApiException: If pipeline is not found.
     """
-    return self._pipelines_api.get_pipeline(id=pipeline_id)
+    if pipeline_id is None and pipeline_name is None:
+      raise ValueError('Either pipeline_id or pipeline_name is required')
+    
+    if pipeline_id:
+      return self._pipelines_api.get_pipeline(id=pipeline_id)
+
+    pipeline_filter = json.dumps({ 
+        "predicates": [ 
+          { 
+            "op":  _FILTER_OPERATIONS["EQUALS"], 
+            "key": "name", 
+            "stringValue": pipeline_name, 
+          }
+        ] 
+      })
+    result = self._pipelines_api.list_pipelines(filter=pipeline_filter)
+    if not result.pipelines:
+      raise ValueError('No pipeline is found with name {}.'.format(pipeline_name))
+    if len(result.pipelines) > 1:
+      raise ValueError('Multiple pipelines is found with name {}.'.format(pipeline_name))
+    return result.pipelines[0]
 
   def delete_pipeline(self, pipeline_id):
     """Delete pipeline.
@@ -1181,11 +1268,12 @@ class Client(object):
     """
     return self._pipelines_api.delete_pipeline(id=pipeline_id)
 
-  def list_pipeline_versions(self, pipeline_id, page_token='', page_size=10, sort_by=''):
+  def list_pipeline_versions(self, pipeline_id: str = None, pipeline_name: str = None, page_token: str = '', page_size: int = 10, sort_by: str = '') -> kfp_server_api.ApiListPipelineVersionsResponse:
     """Lists pipeline versions.
 
     Args:
       pipeline_id: Id of the pipeline to list versions
+      pipeline_name: Name of the pipeline to list versions
       page_token: Token for starting of the page.
       page_size: Size of the page.
       sort_by: One of 'field_name', 'field_name desc'. For example, 'name desc'.
@@ -1194,4 +1282,22 @@ class Client(object):
       A response object including a list of versions and next page token.
     """
 
-    return self._pipelines_api.list_pipeline_versions(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_key_type=kfp_server_api.models.api_resource_type.ApiResourceType.PIPELINE, resource_key_id=pipeline_id)
+    if not pipeline_id:
+      pipeline = self.get_pipeline(pipeline_name=pipeline_name)
+      pipeline_id = pipeline.id
+
+    return self._pipelines_api.list_pipeline_versions(page_token=page_token, page_size=page_size, sort_by=sort_by, resource_key_type=kfp_server_api.api_resource_type.ApiResourceType.PIPELINE, resource_key_id=pipeline_id)
+
+  def delete_pipeline_version(self, version_id: str):
+    """Delete pipeline version.
+
+    Args:
+      version_id: id of the pipeline version.
+
+    Returns:
+      Object. If the method is called asynchronously, returns the request thread.
+
+    Throws:
+      Exception if pipeline version is not found.
+    """
+    return self._pipelines_api.delete_pipeline_version(version_id=version_id)

--- a/sdk/python/kfp/cli/cli.py
+++ b/sdk/python/kfp/cli/cli.py
@@ -17,6 +17,7 @@ import logging
 import sys
 from kfp._client import Client
 from kfp.cli.run import run
+from kfp.cli.recurring_run import recurring_run
 from kfp.cli.pipeline import pipeline
 from kfp.cli.diagnose_me_cli import diagnose_me
 from kfp.cli.experiment import experiment
@@ -57,6 +58,7 @@ def cli(ctx, endpoint, iap_client_id, namespace, other_client_id, other_client_s
 def main():
     logging.basicConfig(format='%(message)s', level=logging.INFO)
     cli.add_command(run)
+    cli.add_command(recurring_run)
     cli.add_command(pipeline)
     cli.add_command(diagnose_me,'diagnose_me')
     cli.add_command(experiment)

--- a/sdk/python/kfp/cli/experiment.py
+++ b/sdk/python/kfp/cli/experiment.py
@@ -106,3 +106,18 @@ def _display_experiment(exp, output_format):
         print_output(table, [], output_format, table_format="plain")
     elif output_format == OutputFormat.json.name:
         print_output(dict(table), [], output_format)
+
+
+@experiment.command()
+@click.option("--experiment-id", default=None, help="The ID of the experiment to archive.")
+@click.option("--experiment-name", default=None, help="The name of the experiment to archive.")
+@click.pass_context
+def archive(ctx: click.Context, experiment_id: str, experiment_name: str):
+    """Archive an experiment"""
+    client = ctx.obj["client"]
+
+    if not experiment_id:
+        experiment = client.get_experiment(experiment_name=experiment_name)
+        experiment_id = experiment.id
+
+    client.archive_experiment(experiment_id=experiment_id)

--- a/sdk/python/kfp/cli/recurring_run.py
+++ b/sdk/python/kfp/cli/recurring_run.py
@@ -1,0 +1,161 @@
+# Copyright 2021 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List, Optional
+import json
+import click
+from kfp.cli.output import print_output, OutputFormat
+
+
+@click.group()
+def recurring_run():
+    """Manage recurring-run resources"""
+    pass
+
+
+@recurring_run.command()
+@click.option('--catchup/--no-catchup', help='Whether the recurring run should catch up if behind schedule.', type=bool)
+@click.option('--cron-expression', help='A cron expression representing a set of times, using 6 space-separated fields, e.g. "0 0 9 ? * 2-6".')
+@click.option('--description', help='The description of the recurring run.')
+@click.option('--enable-caching/--disable-caching', help='Optional. Whether or not to enable caching for the run.', type=bool)
+@click.option('--enabled/--disabled', help='A bool indicating whether the recurring run is enabled or disabled.', type=bool)
+@click.option('--end-time', help='The RFC3339 time string of the time when to end the job.')
+@click.option('--experiment-id', help='The ID of the experiment to create the recurring run under.')
+@click.option('--experiment-name', help='The name of the experiment to create the recurring run under.')
+@click.option('--job-name', help='The name of the recurring run.')
+@click.option('--interval-second', help='Integer indicating the seconds between two recurring runs in for a periodic schedule.')
+@click.option('--max-concurrency', help='Integer indicating how many jobs can be run in parallel.', type=int)
+@click.option('--pipeline-id', help='The ID of the pipeline to use to create the recurring run.')
+@click.option('--pipeline-package-path', help='Local path of the pipeline package(the filename should end with one of the following .tar.gz, .tgz, .zip, .yaml, .yml).')
+@click.option('--start-time', help='The RFC3339 time string of the time when to start the job.')
+@click.option('--version-id', help='The id of a pipeline version.')
+@click.argument("args", nargs=-1)
+@click.pass_context
+def create(
+    ctx: click.Context,
+    experiment_id: str,
+    experiment_name: str,
+    job_name: str,
+    catchup: Optional[bool] = None,
+    cron_expression: Optional[str] = None,
+    enabled: Optional[bool] = None,
+    description: Optional[str] = None,
+    enable_caching: Optional[bool] = None,
+    end_time: Optional[str] = None,
+    interval_second: Optional[int] = None,
+    max_concurrency: Optional[int] = None,
+    params: Optional[dict] = None,
+    pipeline_package_path: Optional[str] = None,
+    pipeline_id: Optional[str] = None,
+    start_time: Optional[str] = None,
+    version_id: Optional[str] = None,
+    args: Optional[List[str]] = None
+):
+    """Create a recurring run."""
+    client = ctx.obj["client"]
+    output_format = ctx.obj['output']
+
+    # Ensure we only split on the first equals char so the value can contain
+    # equals signs too.
+    split_args: List = [arg.split("=", 1) for arg in args or []]
+    params: Dict[str, Any] = dict(split_args)
+    recurring_run = client.create_recurring_run(
+        cron_expression=cron_expression,
+        description=description,
+        enabled=enabled,
+        enable_caching=enable_caching,
+        end_time=end_time,
+        experiment_id=experiment_id,
+        experiment_name=experiment_name,
+        interval_second=interval_second,
+        job_name=job_name,
+        max_concurrency=max_concurrency,
+        no_catchup=not catchup,
+        params=params,
+        pipeline_package_path=pipeline_package_path,
+        pipeline_id=pipeline_id,
+        start_time=start_time,
+        version_id=version_id
+    )
+
+    _display_recurring_run(recurring_run, output_format)
+
+
+@recurring_run.command()
+@click.option('-e', '--experiment-id', help='Parent experiment ID of listed recurring runs.')
+@click.option(
+    '-m',
+    '--max-size',
+    default=100,
+    help="Max size of the listed recurring runs."
+)
+@click.pass_context
+def list(ctx, max_size: int, experiment_id: str):
+    """List recurring runs"""
+    client = ctx.obj['client']
+    output_format = ctx.obj['output']
+
+    response = client.list_recurring_runs(
+        page_size=max_size,
+        sort_by="created_at desc",
+        experiment_id=experiment_id
+    )
+    if response.jobs:
+        _display_recurring_runs(response.jobs, output_format)
+    else:
+        if output_format == OutputFormat.json.name:
+            msg = json.dumps([])
+        else:
+            msg = "No recurring runs found"
+        click.echo(msg)
+
+
+@recurring_run.command()
+@click.option("--job-id", help="id of the recurring_run.")
+@click.option("--job-name", help="name of the recurring_run.")
+@click.pass_context
+def get(ctx, job_id: str, job_name: str):
+    """Get detailed information about an experiment"""
+    client = ctx.obj["client"]
+    output_format = ctx.obj["output"]
+
+    response = client.get_recurring_run(job_id, job_name)
+    _display_recurring_runs(response, output_format)
+
+
+@recurring_run.command()
+@click.argument("job-id")
+@click.pass_context
+def delete(ctx: click.Context, job_id: str):
+    """Delete a recurring run"""
+    client = ctx.obj["client"]
+    client.delete_recurring_run(job_id)
+
+
+def _display_recurring_runs(recurring_runs, output_format):
+    headers = ["Recurring Run ID", "Name"]
+    data = [[rr.id, rr.name] for rr in recurring_runs]
+    print_output(data, headers, output_format, table_format="grid")
+
+
+def _display_recurring_run(recurring_run, output_format):
+    table = [
+        ["Recurring Run ID", recurring_run.id],
+        ["Name", recurring_run.name],
+    ]
+    if output_format == OutputFormat.table.name:
+        print_output([], ["Recurring Run Details"], output_format)
+        print_output(table, [], output_format, table_format="plain")
+    elif output_format == OutputFormat.json.name:
+        print_output(dict(table), [], output_format)


### PR DESCRIPTION
**Description of your changes:**

Pulls in changes we made to the `kfp` CLI in `aip-kfp-sdk`, but refactors them in a way I believe the KFP folks are more likely to accept as a contribution upstream.

To do:
- [x] Pull in changes from `aip-kfp-sdk` to the `kfp` CLI into `zillow-kfp`. See [this PR](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-workflow/aip-kfp-sdk/-/merge_requests/43) in `aip-kfp-sdk`.
- Test out changes on:
    - [x] `ci-cd-template`
    - [ ] `~~foundry-ci-cd-template`~~ - Moved to AIP-5426.
- [x] Remove mentions of `aip-kfp-sdk` from the Sphinx docs.