### PR TITLE
AIP-5634: Add in building metadata-writer image building + pull in cache fix for metadata-writer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,17 +1,19 @@
 include:
   - project: 'analytics/artificial-intelligence/ai-platform/aip-infrastructure/ci-templates/ci-cd-template'
-    ref: &include_ref 'v2'
+    ref: 'v2'
     file: '/blocks/python.yml'
 
 stages:
   - build
 
-build:publish:
+variables:
+  MAJOR_VERSION: "1"
+  MINOR_VERSION: "0"
+
+build:publish-sdk:
   extends: .aip_python_debian_image
   stage: build
   variables:
-    MAJOR_VERSION: "1"
-    MINOR_VERSION: "0"
     PY_LIBRARY_NAME: 'zillow-kfp'
     KFP_VERSION_PATH: "sdk/python/kfp/__init__.py"
   script:
@@ -24,6 +26,7 @@ build:publish:
     PY_LIBRARY_VERSION="${PY_LIBRARY_VERSION}+${KFP_VERSION}"
   # Now write back the zillow-kfp version back to the original location we found the original.
   - sed -i "s/\(__version__ = ['\"]\)[^'\"]*\(['\"]\)/\1${PY_LIBRARY_VERSION}\2/" $KFP_VERSION_PATH
+  - cd sdk/python
   - python setup.py sdist
   # Set up the configuration for Artifactory to publish the python package internally.
   - |
@@ -36,3 +39,19 @@ build:publish:
     password: ${PYPI_PASSWORD}
     EOL
   - python setup.py sdist upload --repository "${ANALYTICS_PYPI_REPOSITORY}"
+
+build:publish-metadata-writer:
+  extends: .aip_python_debian_image
+  stage: build
+  variables:
+    ARTIFACT_NAME: 'zillow-metadata-writer'
+  before_script:
+    - !reference [.generate_docker_image_version, before_script]
+  script:
+    - |
+      docker build \
+        --tag ${IMAGE_REPOSITORY_TAG} \
+        --file backend/metadata_writer/Dockerfile \
+        .
+    - docker login --username ${DOCKER_USERNAME} --password ${DOCKER_API_KEY} ${DOCKER_REPO_URL}
+    - docker push ${IMAGE_REPOSITORY_TAG}

--- a/backend/metadata_writer/requirements.in
+++ b/backend/metadata_writer/requirements.in
@@ -1,2 +1,3 @@
 kubernetes>=8.0.0,<11.0.0
 ml-metadata==1.2.0
+lru-dict>=1.1.7,<2.0.0

--- a/backend/metadata_writer/requirements.txt
+++ b/backend/metadata_writer/requirements.txt
@@ -6,26 +6,27 @@
 #
 absl-py==0.12.0           # via ml-metadata
 attrs==20.3.0             # via ml-metadata
-cachetools==4.2.2         # via google-auth
-certifi==2021.5.30        # via kubernetes, requests
-charset-normalizer==2.0.4  # via requests
-google-auth==2.0.1        # via kubernetes
-grpcio==1.39.0            # via ml-metadata
-idna==3.2                 # via requests
+cachetools==5.0.0         # via google-auth
+certifi==2021.10.8        # via kubernetes, requests
+charset-normalizer==2.0.10  # via requests
+google-auth==2.4.1        # via kubernetes
+grpcio==1.43.0            # via ml-metadata
+idna==3.3                 # via requests
 kubernetes==10.1.0        # via -r -
-ml-metadata==1.2.0        # via -r -
+lru-dict==1.1.7           # via -r -
+ml-metadata==1.5.0        # via -r -
 oauthlib==3.1.1           # via requests-oauthlib
-protobuf==3.17.3          # via ml-metadata
+protobuf==3.19.3          # via ml-metadata
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 python-dateutil==2.8.2    # via kubernetes
 pyyaml==3.13              # via kubernetes
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.26.0          # via kubernetes, requests-oauthlib
-rsa==4.7.2                # via google-auth
-six==1.16.0               # via absl-py, grpcio, kubernetes, ml-metadata, protobuf, python-dateutil
-urllib3==1.26.6           # via kubernetes, requests
-websocket-client==1.2.1   # via kubernetes
+requests==2.27.1          # via kubernetes, requests-oauthlib
+rsa==4.8                  # via google-auth
+six==1.16.0               # via absl-py, google-auth, grpcio, kubernetes, ml-metadata, python-dateutil
+urllib3==1.26.8           # via kubernetes, requests
+websocket-client==1.2.3   # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -15,16 +15,21 @@
 import json
 import hashlib
 import os
-import sys
 import re
+import collections
 import kubernetes
 import yaml
 from time import sleep
+import lru
 
 from metadata_helpers import *
 
 
 namespace_to_watch = os.environ.get('NAMESPACE_TO_WATCH', 'default')
+pod_name_to_execution_id_size = os.environ.get('POD_NAME_TO_EXECUTION_ID_SIZE', 5000)
+workflow_name_to_context_id_size = os.environ.get('WORKFLOW_NAME_TO_CONTEXT_ID_SIZE', 5000)
+pods_with_written_metadata_size = os.environ.get('PODS_WITH_WRITTEN_METADATA_SIZE', 5000)
+debug_files_size = os.environ.get('DEBUG_FILES_SIZE', 5000)
 
 
 kubernetes.config.load_incluster_config()
@@ -133,9 +138,10 @@ def is_kfp_v2_pod(pod) -> bool:
 # They are expected to be lost when restarting the service.
 # The operation of the Metadata Writer remains correct even if it's getting restarted frequently. (Kubernetes only sends the latest version of resource for new watchers.)
 # Technically, we could remove the objects from cache as soon as we see that our labels have been applied successfully.
-pod_name_to_execution_id = {}
-workflow_name_to_context_id = {}
-pods_with_written_metadata = set()
+pod_name_to_execution_id = lru.LRU(pod_name_to_execution_id_size)
+workflow_name_to_context_id = lru.LRU(workflow_name_to_context_id_size)
+pods_with_written_metadata = lru.LRU(pods_with_written_metadata_size)
+debug_paths = collections.deque()
 
 while True:
     print("Start watching Kubernetes Pods created by Argo")
@@ -164,8 +170,15 @@ while True:
             pod_name = obj.metadata.name
 
             # Logging pod changes for debugging
-            with open('/tmp/pod_' + obj.metadata.name + '_' + obj.metadata.resource_version, 'w') as f:
+            debug_path = '/tmp/pod_' + obj.metadata.name + '_' + obj.metadata.resource_version
+            with open(debug_path, 'w') as f:
                 f.write(yaml.dump(obj.to_dict()))
+            debug_paths.append(debug_path)
+
+            # Do some housekeeping, ensure we only keep a fixed size buffer of debug files so we don't
+            # grow the disk size indefinitely for long running pods.
+            if len(debug_paths) > debug_files_size:
+                os.remove(debug_paths.popleft())
 
             assert obj.kind == 'Pod'
 
@@ -372,7 +385,7 @@ while True:
                     patch=metadata_to_add,
                 )
 
-                pods_with_written_metadata.add(obj.metadata.name)
+                pods_with_written_metadata[obj.metadata.name] = None
 
         except Exception as e:
             import traceback


### PR DESCRIPTION
The primary goal of this change is to fix a memory leak in the `metadata-writer` `Deployment` (which is used to watch "completed" Argo Workflow pods and synchronize their state to the KFP metadata store). This will allow us to decrease the memory requests, which currently grows slowly but linearly, from 16Gb -> < 1Gb (still need to play with the exact figures). See [this PR](https://gitlab.zgtools.net/analytics/artificial-intelligence/ai-platform/aip-infrastructure/aip-k8s-manifests/-/merge_requests/241) in `aip-k8s-manifests` for where we're pulling in this change!

To do:
- [x] Pulls in open source change we're contributing via: https://github.com/kubeflow/pipelines/pull/7199
- [x] Also builds the `metadata-writer` image and publishes it to Artifactory so we can use the fix in the short-term.