### PR TITLE
Correctly prints run details in json format

### DIFF
--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -175,7 +175,10 @@ def _display_run(client: click.Context,
             if key not in ['pipeline_spec'
                           ]  # useless but too much detailed field
         }
-        click.echo(data)
+        if output_format == OutputFormat.json.name:
+            click.echo(json.dumps(data, indent=4))
+        else:
+            click.echo(data)
         return
 
     _print_runs([run], output_format)


### PR DESCRIPTION
**Description of your changes:**
- Correctly output run details in JSON format with `--output json` option specified. Without this fix, python dict is dumped directly, requiring additional conversion from python dict to JSON format in CICD code.