### PR TITLE
Add enable / disable recurring run

### DIFF
--- a/sdk/python/kfp/cli/recurring_run.py
+++ b/sdk/python/kfp/cli/recurring_run.py
@@ -207,7 +207,7 @@ def enable(ctx: click.Context, job_id: str):
 @click.argument("job-id")
 @click.pass_context
 def disable(ctx: click.Context, job_id: str):
-    """Enable a recurring run."""
+    """Disable a recurring run."""
     client = ctx.obj["client"]
     client.disable_job(job_id=job_id)
     click.echo(f"Disabled job {job_id}.")

--- a/sdk/python/kfp/cli/recurring_run.py
+++ b/sdk/python/kfp/cli/recurring_run.py
@@ -193,6 +193,26 @@ def delete(ctx: click.Context, job_id: str):
     client.delete_job(job_id)
 
 
+@recurring_run.command()
+@click.argument("job-id")
+@click.pass_context
+def enable(ctx: click.Context, job_id: str):
+    """Enable a recurring run."""
+    client = ctx.obj["client"]
+    client.enable_job(job_id=job_id)
+    click.echo(f"Enabled job {job_id}.")
+
+
+@recurring_run.command()
+@click.argument("job-id")
+@click.pass_context
+def disable(ctx: click.Context, job_id: str):
+    """Enable a recurring run."""
+    client = ctx.obj["client"]
+    client.disable_job(job_id=job_id)
+    click.echo(f"Disabled job {job_id}.")
+
+
 def _display_recurring_runs(recurring_runs: List[kfp_server_api.ApiJob],
                             output_format: OutputFormat):
     headers = ["Recurring Run ID", "Name"]


### PR DESCRIPTION
**Description of your changes:**
- Add recurring-run enable
- Add recurring-run disable

Both functions are ported from PR https://github.com/kubeflow/pipelines/pull/7606 as `feature/zg` doesn't contain the corresponding commits yet. 

These are needed to not interrupt runs spawned by the previous recurring runs. 
