### PR TITLE
Relax typing-extensions

### DIFF
--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -36,4 +36,4 @@ fire>=0.3.1,<1
 google-api-python-client>=1.7.8,<2
 pydantic>=1.8.2,<2
 dataclasses>=0.8,<1; python_version<"3.7"
-typing-extensions>=3.7.4,<4; python_version<"3.9"
+typing-extensions>=3.7.4,<5; python_version<"3.9"

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -55,7 +55,7 @@ REQUIRES = [
     'typer>=0.3.2,<1.0',
     # Standard library backports
     'dataclasses;python_version<"3.7"',
-    'typing-extensions>=3.7.4,<4;python_version<"3.9"',
+    'typing-extensions>=3.7.4,<5;python_version<"3.9"',
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
Relax typing-extensions to solve version conflicts in downstream tasks.

Mimicking the same change from OSS: https://github.com/kubeflow/pipelines/commit/1118f4859bb49c4465902a3ebf48851541f74a46