### PR TITLE
AIP-7888 relax PyYAML to <7 & jsonschema to <5

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -24,7 +24,7 @@ NAME = 'zillow-kfp'  # 'kfp'
 # accordingly.
 REQUIRES = [
     'absl-py>=0.9,<=0.11',
-    'PyYAML>=5.3,<6',
+    'PyYAML>=5.3,<7',
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
     'google-cloud-storage>=1.20.0,<2',

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -41,7 +41,7 @@ REQUIRES = [
     # kfp-server-api.
     # Note, please also update ./requirements.in
     'kfp-server-api>=1.1.2,<2.0.0',
-    'jsonschema>=3.0.1,<4',
+    'jsonschema>=3.0.1,<5',
     'tabulate>=0.8.6,<1',
     'click>=7.1.2,<9',
     'Deprecated>=1.2.7,<2',


### PR DESCRIPTION
There are no real breaking changes in PyYaml 6.0.  
Except for:
* dropping Python 2.7
* always require `Loader` arg to `yaml.load()`.  Which kfp already does and would be caught early.

see https://github.com/yaml/pyyaml/blob/main/CHANGES